### PR TITLE
Add the rolled-up topic taxonomy and skin the theme to match Atlas

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,42 @@
 `ckanext-spark` provides the Data@Spark theme used by Spark!'s public CKAN
 catalog at [data.buspark.io](https://data.buspark.io).
 
-The extension changes presentation only. It does not patch CKAN core or define
-custom dataset schemas, authorization rules, actions, or database tables.
+The extension is presentation plus the topic taxonomy. It does not patch CKAN
+core or define custom dataset schemas, authorization rules, actions, or database
+tables; the one thing it writes is the fixed set of topic groups, via the
+`spark init-topics` command below.
+
+## Topics
+
+Datasets are categorised with a fixed, rolled-up taxonomy of 11 subject areas
+(the "academic disciplines" list, not the detailed 40–50 item breakdown — CKAN's
+topic model is flat, so only the top level is representable). The list is
+defined in `ckanext/spark/topics.py` and is kept identical to `SPARK_TOPICS` in
+the Atlas project gallery, so a dataset and a project describe themselves with
+the same words.
+
+Topics are CKAN **groups** rather than free tags. Groups are flat, so they fit
+the same constraint tags would, but unlike tags they are a controlled vocabulary
+(no typos, no near-duplicates), they get a browsable page each, and CKAN already
+facets search on them.
+
+Assigning a topic is a **second step after creating a dataset**: CKAN 2.11's
+dataset form has an Organization selector but no group selector, so a topic is
+set from the dataset's *Groups* tab (`/dataset/groups/<name>`) or by adding the
+dataset from the topic's own page. Worth knowing, because it means a dataset can
+be created with no topic at all and nothing will complain. Putting an 11-way
+topic picker directly on the dataset form is the obvious follow-up if datasets
+start landing untagged.
+
+Create the topic groups on a new site (safe to re-run; it repairs a wrong title
+or a soft-deleted topic and leaves descriptions and images alone):
+
+```bash
+ckan -c /etc/ckan/default/ckan.ini spark init-topics
+```
+
+The unrelated `featured` **tag** still flags datasets for the homepage's
+Featured tab. That's a flag, not a topic.
 
 ## Compatibility
 
@@ -31,20 +65,29 @@ Restart CKAN after installing or updating the extension.
 
 ## Development
 
-Install the test dependency:
+`docker-compose.dev.yml` runs a complete local CKAN 2.11 with the repo
+bind-mounted, so template and CSS edits appear on reload:
 
 ```bash
-pip install -r dev-requirements.txt
+docker compose -f docker-compose.dev.yml up -d
+docker compose -f docker-compose.dev.yml exec ckan \
+    ckan -c "$CKAN_INI" spark init-topics
+open http://localhost:5000        # sign in as ckan_admin / test1234
 ```
 
-Run the test suite from a configured CKAN environment:
+Run the tests inside that container, which is the only place CKAN itself is
+importable:
 
 ```bash
-pytest
+docker compose -f docker-compose.dev.yml exec ckan \
+    pytest --ckan-ini=test.ini ckanext/spark/tests
 ```
 
-The Data@Spark deployment repository supplies the reproducible CKAN container
-environment used for integration and render testing.
+This stack is for local work only — the credentials in it are fixed test values
+and it serves plain HTTP on localhost. It is deliberately separate from
+`infra-public-data-portal`, whose compose is a half-finished Kubernetes
+migration still pinned to CKAN 2.10 and Solr 8 (Solr 8 cannot serve a 2.11
+schema). Deployment still comes from that repository, not this one.
 
 ## License
 

--- a/ckanext/spark/cli.py
+++ b/ckanext/spark/cli.py
@@ -1,19 +1,60 @@
 import click
+from ckan.plugins import toolkit
+
+from ckanext.spark.topics import SPARK_TOPICS
 
 
 @click.group(short_help="spark CLI.")
 def spark():
-    """spark CLI.
-    """
+    """spark CLI."""
     pass
 
 
-@spark.command()
-@click.argument("name", default="spark")
-def command(name):
-    """Docs.
+def _sysadmin_context():
+    """An action context allowed to create groups.
+
+    Seeding runs from the command line with no logged-in user, so it borrows the
+    site user rather than requiring an operator to pass credentials.
     """
-    click.echo("Hello, {name}!".format(name=name))
+    site_user = toolkit.get_action("get_site_user")({"ignore_auth": True}, {})
+    return {"user": site_user["name"], "ignore_auth": True}
+
+
+@spark.command()
+def init_topics():
+    """Create (or repair) the Data@Spark topic groups.
+
+    Safe to re-run: existing topics keep any description and image an editor has
+    since added, and only a wrong title or a soft-deleted state is corrected.
+    """
+    context = _sysadmin_context()
+
+    for name, title in SPARK_TOPICS:
+        try:
+            existing = toolkit.get_action("group_show")(
+                dict(context), {"id": name, "include_datasets": False}
+            )
+        except toolkit.ObjectNotFound:
+            toolkit.get_action("group_create")(
+                dict(context), {"name": name, "title": title}
+            )
+            click.echo(f"created  {name}")
+            continue
+
+        # Only touch what's actually wrong. A topic soft-deleted through the UI
+        # still occupies its name, so reviving it is the only way a re-run can
+        # restore the full taxonomy.
+        patch = {}
+        if existing.get("title") != title:
+            patch["title"] = title
+        if existing.get("state") != "active":
+            patch["state"] = "active"
+
+        if patch:
+            toolkit.get_action("group_patch")(dict(context), {"id": name, **patch})
+            click.echo(f"repaired {name} ({', '.join(patch)})")
+        else:
+            click.echo(f"ok       {name}")
 
 
 def get_commands():

--- a/ckanext/spark/helpers.py
+++ b/ckanext/spark/helpers.py
@@ -4,6 +4,8 @@ from datetime import datetime
 
 from ckan.plugins import toolkit
 
+from ckanext.spark.topics import SPARK_TOPICS
+
 
 def _datasets(**params):
     """Return dataset search results without per-dataset API calls."""
@@ -25,11 +27,37 @@ def popular_datasets():
     return _datasets(sort="views_recent desc")
 
 
-def groups(limit=None):
-    params = {"all_fields": True}
-    if limit is not None:
-        params["limit"] = limit
-    return toolkit.get_action("group_list")({}, params)
+def topics():
+    """Return the canonical topic taxonomy, each with its live dataset count.
+
+    Always returns all of SPARK_TOPICS in taxonomy order, including topics with
+    no datasets yet -- the point of a fixed taxonomy is that the shape of it is
+    visible before it's full. Counts come from one faceted search rather than a
+    query per topic.
+    """
+    result = toolkit.get_action("package_search")(
+        {},
+        {
+            "rows": 0,
+            "facet.field": ["groups"],
+            # Defensive, not a bugfix: CKAN feeds facet.limit from
+            # `search.facets.limit`, which defaults to 50, so the 11 topics fit
+            # today. Pinning -1 means the homepage can't start silently dropping
+            # the least-used topics if someone lowers that config, or if the
+            # taxonomy grows past it. (The other CKAN setting,
+            # `search.facets.default` = 10, is a UI display cap and never
+            # reaches this query.)
+            "facet.limit": -1,
+        },
+    )
+    # Missing on a brand-new site with an empty index.
+    counts = result.get("search_facets", {}).get("groups", {}).get("items", [])
+    counts = {item["name"]: item["count"] for item in counts}
+
+    return [
+        {"name": name, "title": title, "count": counts.get(name, 0)}
+        for name, title in SPARK_TOPICS
+    ]
 
 
 def format_date(value):
@@ -45,6 +73,6 @@ def get_helpers():
         "spark_all_datasets": all_datasets,
         "spark_featured_datasets": featured_datasets,
         "spark_popular_datasets": popular_datasets,
-        "spark_groups": groups,
+        "spark_topics": topics,
         "spark_format_date": format_date,
     }

--- a/ckanext/spark/plugin.py
+++ b/ckanext/spark/plugin.py
@@ -1,15 +1,19 @@
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 
-from ckanext.spark import helpers
+from ckanext.spark import cli, helpers
 
 
 class SparkPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.ITemplateHelpers)
+    plugins.implements(plugins.IClick)
 
     def get_helpers(self):
         return helpers.get_helpers()
+
+    def get_commands(self):
+        return cli.get_commands()
 
     def update_config(self, config_):
         toolkit.add_template_directory(config_, "templates")

--- a/ckanext/spark/public/spark-frtend.css
+++ b/ckanext/spark/public/spark-frtend.css
@@ -1,30 +1,77 @@
+/* ── Data@Spark theme ───────────────────────────────────────────────────────
+   Skinned to match the Atlas project gallery (spark-portfolio/hub). The tokens
+   below are lifted from Atlas's app/globals.css so the two properties read as
+   one product: same accent, same Space Grotesk / IBM Plex pairing, same
+   near-black ink and hairline greys.
+
+   Atlas gets its fonts from next/font (self-hosted at build time); CKAN is
+   server-rendered Jinja with no build step, so they come from Google Fonts.
+   The `display=swap` matters here: without it a slow font response blanks the
+   whole page instead of just reflowing it once.
+
+   Deliberately NOT copied from Atlas: the spinning logo. */
+@import url("https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap");
+
+:root {
+    /* Atlas's brand teal. At 3.15:1 on white it clears WCAG AA for UI
+       components (1.4.11) but NOT for text (1.4.3), so it is used only for
+       borders, focus rings and the active-tab indicator -- never for a text
+       colour and never as a fill under white text. */
+    --spark-accent: #0fa392;
+    /* Darkened to 4.89:1 on white, which also makes white-on-it 4.89:1. One
+       token therefore serves both accent text and accent-filled buttons. */
+    --spark-accent-text: #0b7f72;
+    --spark-accent-deep: #096b60;
+    --spark-display: "Space Grotesk", system-ui, sans-serif;
+    --spark-body: "IBM Plex Sans", system-ui, sans-serif;
+    --spark-mono: "IBM Plex Mono", ui-monospace, monospace;
+    --spark-ink: #16191c;
+    --spark-muted: #55595e;
+    --spark-faint: #6b6f75;  /* 5.05:1 on white, 4.78:1 on --spark-bg-soft */
+    --spark-line: #ececec;
+    --spark-line-strong: #dcdcdc;
+    --spark-bg: #ffffff;
+    --spark-bg-soft: #f7f9f8;
+}
+
 /* Global Styles */
 [role=main],
 .main {
-    background-color: #F2F2F2;
-    font-family: "Montserrat";
+    background-color: var(--spark-bg);
+    font-family: var(--spark-body);
     font-size: 15px;
+    color: var(--spark-ink);
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
 }
 
-/* Home Page Styles */
+::selection {
+    background: rgba(15, 163, 146, 0.25);
+}
+
+/* Home Page Styles.
+   Atlas leads with a white intro band and lets the accent do the pointing, so
+   the full-bleed teal hero this used to be is gone. */
 .home-page-main {
-    background-color: #00a99e;
+    background-color: var(--spark-bg);
 }
 
-/* Account Masthead Styles */
+/* Account Masthead Styles.
+   Atlas has no teal utility bar; the near-black ink reads as chrome rather
+   than as a second brand colour competing with the accent. */
 .account-masthead {
-    background-color: #00a99e;
+    background-color: var(--spark-ink);
     text-transform: uppercase;
-    letter-spacing: 1.5px;
+    letter-spacing: 0.1em;
     color: #FFFFFF;
-    border-bottom: 2px solid #00a99e;
+    border-bottom: none;
 }
 
 .account-masthead .account ul li a {
     color: #FFFFFF;
-    font-weight: normal;
-    font-size: 14px;
-    font-family: "Montserrat", sans-serif;
+    font-weight: 400;
+    font-size: 12px;
+    font-family: var(--spark-mono);
 }
 
 .account-masthead .account ul li {
@@ -35,10 +82,10 @@
 
 /* Masthead Styles */
 .masthead {
-    font-family: "Plus Jakarta Sans", sans-serif;
+    font-family: var(--spark-display);
     background-color: #FFFFFF;
-    border-bottom: none;
-    color: black !important;
+    border-bottom: 1px solid var(--spark-line);
+    color: var(--spark-ink) !important;
 }
 
 .masthead .navbar .logo img {
@@ -52,27 +99,39 @@
     padding-right: 20px;
 }
 
+/* Was 70px white-on-teal. Now ink-on-white, and fluid: 70px was already
+   overflowing narrow viewports, and "WELCOME TO / DATA@SPARK!" is two lines. */
 .page-heading {
-    font-family: "Plus Jakarta Sans", sans-serif;
-    font-size: 70px;
+    font-family: var(--spark-display);
+    font-size: clamp(38px, 5.5vw, 64px);
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    line-height: 1.05;
     margin-top: 40px;
-    margin-bottom: 30px;
+    margin-bottom: 24px;
     padding: 0px;
-    color: #FFFFFF;
+    color: var(--spark-ink);
+    text-transform: none;
 }
 
 .search-heading {
-    color: #FFFFFF;
+    color: var(--spark-ink);
+    font-family: var(--spark-display);
+    font-weight: 700;
+    font-size: 18px;
+    padding: 0 0 12px;
+    text-transform: none;
 }
 
 .masthead .main-navbar ul li:hover a,
 .masthead .main-navbar ul li:focus a,
 .masthead .main-navbar ul li.active a {
-    color: #00A99E;
+    color: var(--spark-accent-text);
     background-color: transparent;
     text-decoration: underline;
-    text-decoration-color: #00A99E;
-    text-decoration-thickness: 3px;
+    text-decoration-color: var(--spark-accent);
+    text-underline-offset: 4px;
+    text-decoration-thickness: 2px;
 }
 
 button.btn[type="submit"] {
@@ -86,14 +145,14 @@ button.btn[type="submit"] {
 #field-sitewide-search.form-control.me-2 {
     border-radius: 20px;
     background-color: #FFFFFF;
-    color: black;
+    color: var(--spark-ink);
     width: 200px;
     box-shadow: none;
 }
 
 #field-sitewide-search::placeholder {
     text-align: right;
-    color: #727272;
+    color: var(--spark-muted);
 }
 
 .container,
@@ -103,34 +162,39 @@ button.btn[type="submit"] {
 .container-lg,
 .container-md,
 .container-sm {
-    font-family: "Plus Jakarta Sans", sans-serif;
+    font-family: var(--spark-body);
     padding-bottom: 5px;
 }
 
 .masthead .main-navbar ul li a {
-    font-family: "Montserrat", sans-serif;
-    color: #727272;
-    text-transform: uppercase;
-    font-size: 14px;
+    font-family: var(--spark-body);
+    color: var(--spark-muted);
+    text-transform: none;
+    font-size: 13.5px;
     padding: 0.6rem 0.5rem;
 }
 
+/* Atlas's eyebrow treatment: mono, uppercase, wide tracking, accent. */
 .header-tag-line {
     margin-bottom: 20px;
     margin-top: 30px;
-    color: #FFFFFF;
+    color: var(--spark-accent-text);
+    font-family: var(--spark-mono);
+    font-size: 12px;
+    letter-spacing: 0.13em;
+    text-transform: uppercase;
 }
 
 .text-block {
-    font-family: "Plus Jakarta Sans", sans-serif !important;
-    color: #aaaaaa;
+    font-family: var(--spark-body) !important;
+    color: var(--spark-muted);
 }
 
 /* Main Content Styles */
 .main {
-    background-color: #F2F2F2;
+    background-color: var(--spark-bg);
     height: auto;
-    font-family: "Plus Jakarta Sans", sans-serif;
+    font-family: var(--spark-body);
 }
 
 .main-hero {
@@ -139,25 +203,32 @@ button.btn[type="submit"] {
 
 /* Toolbar Styles */
 .toolbar a {
-    text-transform: uppercase;
-    font-family: "Plus Jakarta Sans", sans-serif;
+    text-transform: none;
+    font-family: var(--spark-mono);
 }
 
 .toolbar .breadcrumb a {
-    color: black;
-    font-size: 14px;
+    color: var(--spark-muted);
+    font-size: 12.5px;
+}
+
+.toolbar .breadcrumb a:hover {
+    color: var(--spark-accent-text);
 }
 
 .dataset-heading a {
-    color: #aaaaaa;
+    color: var(--spark-muted);
 }
 
-/* Grid Container Styles */
+/* Grid Container Styles.
+   Was a fixed 250px gutter with max-width: fit-content, which overflowed on
+   anything narrower than a wide desktop. minmax + auto-fit collapses to a
+   single column on small screens without a media query. */
 .grid-container {
     display: grid;
-    grid-template-columns: 1fr 1fr;
-    grid-gap: 250px;
-    max-width: fit-content;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 40px;
+    align-items: start;
 }
 
 div.module-search.card.box {
@@ -165,66 +236,123 @@ div.module-search.card.box {
     margin-bottom: 20px;
 }
 
-/* Homepage Styles */
+/* Homepage Styles.
+   The search panel was a solid #73B5B7 block carrying white text; on the new
+   white page that reads as a stray swatch, so it becomes an Atlas-style card:
+   white, hairline border, soft radius. */
 .homepage .module-search .search-form {
-    background-color: #73B5B7;
-    font-family: "Plus Jakarta Sans", sans-serif;
-    padding-top: 20px;
+    background-color: var(--spark-bg);
+    font-family: var(--spark-body);
+    padding: 20px;
     margin-bottom: 0px;
+    border: 1px solid var(--spark-line);
+    border-radius: 10px;
 }
 
 .homepage .module-search {
-    color: #FFFFFF;
+    color: var(--spark-ink);
     padding: 0;
     border-width: 0;
     border-style: none;
-}
-
-.homepage .module-search .tags {
-    background-color: #FFFFFF;
-    color: #00A99E;
-    padding: 0px;
-}
-
-.homepage .module-search {
     margin-top: 0px;
 }
 
+.homepage .module-search .tags {
+    background-color: transparent;
+    color: var(--spark-ink);
+    padding: 18px 0 0;
+}
+
+.homepage .module-search .tags h3 {
+    font-family: var(--spark-mono);
+    font-size: 10.5px;
+    letter-spacing: 0.13em;
+    text-transform: uppercase;
+    color: var(--spark-faint);
+    padding: 0 0 11px;
+}
+
+/* Atlas's chip: pill, mono, hairline border; fills ink on hover. */
+.homepage .module-search .tags .tag {
+    display: inline-block;
+    font-family: var(--spark-mono);
+    font-size: 12px;
+    letter-spacing: 0.02em;
+    padding: 7px 13px;
+    margin: 0 6px 6px 0;
+    border-radius: 20px;
+    border: 1px solid var(--spark-line-strong);
+    background: var(--spark-bg);
+    color: var(--spark-muted);
+    line-height: 1;
+    text-decoration: none;
+}
+
+.homepage .module-search .tags .tag:hover {
+    background: var(--spark-ink);
+    border-color: var(--spark-ink);
+    color: #fff;
+    text-decoration: none;
+}
+
 .homepage .module-search .search-form input {
-    font-size: 14px;
-    padding: 8px;
+    font-size: 14.5px;
+    font-family: var(--spark-body);
+    padding: 11px 13px;
+    border: 1px solid var(--spark-line-strong);
+    border-radius: 7px;
+    box-shadow: none;
+}
+
+.homepage .module-search .search-form input:focus {
+    border-color: var(--spark-accent);
+    box-shadow: none;
+    outline: none;
 }
 
 /* Headline Styles */
 .heading-headline {
     text-align: center;
     margin-top: 70px;
-    margin-bottom: 50px;
-    color: #000000;
-    font-size: 35px;
-    font-weight: bold;
+    margin-bottom: 18px;
+    color: var(--spark-ink);
+    font-family: var(--spark-display);
+    font-size: clamp(26px, 3vw, 38px);
+    font-weight: 700;
+    letter-spacing: -0.02em;
 }
 
 /* Headline Section Styles */
 .headline-section {
-    background-color: #FFFFFF;
+    background-color: var(--spark-bg-soft);
+    border-top: 1px solid var(--spark-line);
+    border-bottom: 1px solid var(--spark-line);
+    padding: 8px 0 40px;
 }
 
 .data-headline {
     text-align: center;
-    margin-top: 30px;
-    margin-bottom: 50px;
-    color: #000000;
+    margin-top: 0;
+    margin-bottom: 20px;
+    color: var(--spark-muted);
+    font-size: 16px;
+    line-height: 1.6;
+    max-width: 62ch;
+    margin-left: auto;
+    margin-right: auto;
 }
 
-/* Index Layout Sections Styles */
+/* Index Layout Sections Styles.
+   The 4px accent rules top and bottom were the loudest thing on the page;
+   Atlas separates bands with hairlines and lets type carry the hierarchy. */
 .index-layout-sections {
-    background-color: #f2f2f2;
-    font-family: "Montserrat", sans-serif;
-    color: #000000;
-    font-weight: bold;
-    border-top: 4px solid #00a99e;
-    border-bottom: 4px solid #00a99e;
+    background-color: var(--spark-bg);
+    font-family: var(--spark-body);
+    color: var(--spark-ink);
+    font-weight: 400;
+    border-top: none;
+    border-bottom: 1px solid var(--spark-line);
+    padding-top: 8px;
 }
 
 /* Layout Header Links Styles */
@@ -236,7 +364,7 @@ div.module-search.card.box {
 }
 
 .layout-header-links:focus {
-    color: #00a99e;
+    color: var(--spark-accent-text);
 }
 
 /* Layout Data Styles */
@@ -250,14 +378,20 @@ div.module-search.card.box {
 
 /* Site Footer Styles */
 .site-footer {
-    background: #FFFFFF;/*#00a99e;*/
+    background: #FFFFFF;/*var(--spark-accent);*/
     color: black; /* #000000;*/
 }
 
-/* Tab Container Styles */
+/* Tab Container Styles.
+   space-between spread four tabs edge to edge on wide screens; a left-aligned
+   row under a hairline reads as a tab strip instead of a nav bar. */
 .tab-container {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-start;
+    gap: 28px;
+    flex-wrap: wrap;
+    border-bottom: 1px solid var(--spark-line);
+    margin-top: 36px;
 }
 
 /* Page Header Nav Tabs Styles */
@@ -265,34 +399,56 @@ div.module-search.card.box {
     text-transform: uppercase;
 }
 
-/* Tab Styles */
+/* Tab Styles.
+   The tabs are <button>s, so the browser default background/border has to be
+   cleared explicitly or they render as grey chrome buttons. The active marker
+   is a 2px accent rule sitting on the container's hairline -- hence the -1px
+   bottom margin, which pulls it over that line instead of below it. */
 .tab {
-    font-size: 20px;
+    font-size: 15px;
+    font-weight: 600;
     cursor: pointer;
-    padding: 5px;
-    color: #000000;
-    font-family: "Plus Jakarta Sans", sans-serif !important;
-    transition: color 0.3s, border-color 0.3s;
+    padding: 10px 2px;
+    margin-bottom: -1px;
+    color: var(--spark-muted);
+    background: none;
+    border: none;
+    border-bottom: 2px solid transparent;
+    font-family: var(--spark-display) !important;
+    transition: color 0.18s, border-color 0.18s;
 }
 
-.tab:hover,
+.tab:hover {
+    color: var(--spark-ink);
+    text-decoration: none;
+}
+
 .tab.active {
-    color: #00A99E;
-    border-color: #00A99E;
-    text-decoration: underline;
-    text-decoration-color: #00A99E;
-    text-underline-offset: 3px;
-    text-decoration-thickness: 2px;
+    color: var(--spark-ink);
+    border-bottom-color: var(--spark-accent);
+    text-decoration: none;
 }
 
 /* Menu Head Content Styles */
 .menu-head-content {
-    color: #FFFFFF;
+    color: var(--spark-muted);
+    line-height: 1.6;
+    max-width: 46ch;
 }
 
-/* Tab Content Styles */
+/* Tab Content Styles.
+   The tab panels are revealed by spark_theme.js. With JS off, every panel used
+   to stay hidden and the homepage module rendered completely blank -- including
+   the topic taxonomy. Showing the first panel from CSS means no-JS visitors get
+   dataset discovery and can still reach every topic via the Topics nav item.
+   The script sets inline display, which outranks this, so switching is
+   unaffected. (Full no-JS + accessible tab semantics is BU-Spark/ckanext-spark#4.) */
 .tab-content {
     display: none;
+}
+
+#tab-datasets {
+    display: block;
 }
 
 /* Images and SVG Styles */
@@ -334,7 +490,7 @@ img, svg {
 
 /* About Link Footer Styles */
 .about-link-footer {
-    color: #00a99e;
+    color: var(--spark-accent-text);
     font-weight: bold;
 }
 
@@ -342,14 +498,14 @@ img, svg {
 div.notes.embedded-content {
     color: black;
     font-size: 13px;
-    font-family: "Plus Jakarta Sans", sans-serif;
+    font-family: var(--spark-display);
     line-height: 2;
     margin-left: 20px;
 }
 
 .page-header.module-content {
     display: none;
-    background-color: #F2F2F2;
+    background-color: var(--spark-bg);
 }
 
 .module-content {
@@ -358,7 +514,7 @@ div.notes.embedded-content {
 
 /* Secondary Styles */
 .secondary {
-    font-family: "Plus Jakarta Sans", sans-serif;
+    font-family: var(--spark-display);
     font-size: 15px;
 }
 
@@ -387,26 +543,34 @@ div.notes.embedded-content {
     gap: 20px;
 }
 
-/* Home Card Styles */
+/* Home Card Styles.
+   Atlas's card: hairline border, soft radius, lifts on hover. The fixed
+   300px width is gone -- the container is now a grid, so the track sizes the
+   card and it no longer overflows below ~1000px. Height stays fixed so the
+   absolutely-positioned .view-button has a predictable bottom to sit on. */
 .home-card {
     position: relative;
-    flex: 0 0 calc(33.33% - 60px);
-    margin: 10px;
     display: flex;
     flex-direction: column;
     justify-content: initial;
     align-items: center;
-    background-color: #FFFFFF;
-    border: 1px solid #000000;
+    background-color: var(--spark-bg);
+    border: 1px solid var(--spark-line);
     border-radius: 8px;
-    border-color: #727272;
-    padding: 10px;
+    padding: 16px;
     box-sizing: border-box;
     height: 200px;
-    width: 300px;
-    font-size: 16px;
-    font-family: "Montserrat", sans-serif;
-    font-weight: bold;
+    width: auto;
+    font-size: 15px;
+    font-family: var(--spark-body);
+    font-weight: 400;
+    transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+}
+
+.home-card:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 10px 26px rgba(0, 0, 0, 0.1);
+    border-color: #d8d8d8;
 }
 
 .card-heading {
@@ -419,83 +583,161 @@ div.notes.embedded-content {
     margin-right: auto;
 }
 
+/* The organisation label above a dataset title -- Atlas's mono eyebrow. */
 .topic-name {
-    color: #00A99E;
-    font-weight: normal;
+    color: var(--spark-accent-text);
+    font-family: var(--spark-mono);
+    font-size: 10.5px;
+    letter-spacing: 0.13em;
+    text-transform: uppercase;
+    font-weight: 500;
     margin: 0;
 }
 
 .topic-date {
-    color: #727272;
+    color: var(--spark-muted);
     margin: 0;
 }
 
+/* Grid, not space-between flex: a row with fewer than three cards used to
+   spread them to the edges, so the last row never lined up with the ones
+   above it. auto-fill keeps the columns aligned and collapses to one on
+   narrow screens without a media query. */
 .home-card-container {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    align-items: flex-start;
-    font-family: "Plus Jakarta Sans", sans-serif;
-    color: black;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: 20px;
+    align-items: stretch;
+    font-family: var(--spark-body);
+    color: var(--spark-ink);
+    padding: 28px 0 0;
 }
 
 .home-card-content {
     align-items: center;
     width: 100%;
     word-wrap: break-word;
-    font-family: "Plus Jakarta Sans", sans-serif;
-    color: black;
+    font-family: var(--spark-body);
+    color: var(--spark-ink);
     text-align: center;
 }
 
 .dataset-name {
-    color: black;
-    font-weight: bold;
+    color: var(--spark-ink);
+    font-family: var(--spark-display);
+    font-weight: 600;
+    font-size: 16px;
+    line-height: 1.3;
+    letter-spacing: -0.01em;
     margin-bottom: 10px;
 }
 
 .last-updated {
-    color: #A3A3A3;
+    color: var(--spark-muted);
     font-size: 13px;
     font-weight: normal;
     margin-bottom: 5px;
 }
 
 .formatted-date {
-    color: #727272;
+    color: var(--spark-muted);
 }
 
 .view-button {
     position: absolute;
-    bottom: 10px;
+    bottom: 14px;
     left: 50%;
-    width: 90%;
+    width: calc(100% - 32px);
     text-align: center;
     transform: translateX(-50%);
     background-color: transparent;
-    border: 2px solid #00A99E;
-    border-radius: 20px;
-    color: #00A99E;
-    font-family: "Plus Jakarta Sans", sans-serif;
-    font-size: 14px;
-    padding: 8px 15px;
+    border: 1px solid var(--spark-line-strong);
+    border-radius: 7px;
+    color: var(--spark-ink);
+    font-family: var(--spark-display);
+    font-weight: 600;
+    font-size: 13.5px;
+    padding: 9px 15px;
     cursor: pointer;
-    transition: background-color 0.3s, color 0.3s;
+    transition: background-color 0.18s, color 0.18s, border-color 0.18s;
     text-decoration: none;
 }
 
 .view-button:hover {
-    background-color: #00A99E;
+    background-color: var(--spark-accent-text);
+    border-color: var(--spark-accent-text);
     color: #FFFFFF;
     text-decoration: none;
 }
 
-.dataset-label {
-    background-color: #00A99E;
-    color: #FFFFFF;
+/* ── Topic taxonomy grid (homepage "Topics" tab) ────────────────────────────
+   The full fixed taxonomy, so this is a denser tile than a dataset card: no
+   fixed height, no button, just term + count. Topics with no datasets yet stay
+   visible but recede, because an empty category is still information about how
+   the collection is organised. */
+.topic-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 12px;
+    padding: 28px 0 0;
+}
+
+.topic-tile {
+    display: flex;
+    flex-direction: column;
+    gap: 7px;
+    padding: 16px 18px;
+    background: var(--spark-bg);
+    border: 1px solid var(--spark-line);
+    border-radius: 8px;
+    text-decoration: none;
+    transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+}
+
+.topic-tile:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 10px 26px rgba(0, 0, 0, 0.1);
+    border-color: #d8d8d8;
+    text-decoration: none;
+}
+
+.topic-tile-name {
+    font-family: var(--spark-display);
+    font-weight: 600;
+    font-size: 15px;
+    line-height: 1.3;
+    letter-spacing: -0.01em;
+    color: var(--spark-ink);
+}
+
+.topic-tile-count {
+    font-family: var(--spark-mono);
+    font-size: 11px;
+    letter-spacing: 0.06em;
     text-transform: uppercase;
-    font-family: "Plus Jakarta Sans", sans-serif;
-    font-weight: normal;
+    color: var(--spark-accent-text);
+}
+
+.topic-tile.is-empty .topic-tile-name {
+    color: var(--spark-muted);
+}
+
+.topic-tile.is-empty .topic-tile-count {
+    color: var(--spark-faint);
+}
+
+/* Additional-info row labels: Atlas styles these as quiet mono keys, not
+   filled accent chips (a table of teal blocks was the old look's heaviest
+   element on the dataset page). */
+.dataset-label {
+    background-color: var(--spark-bg-soft);
+    color: var(--spark-muted);
+    text-transform: uppercase;
+    font-family: var(--spark-mono);
+    font-size: 10.5px;
+    letter-spacing: 0.1em;
+    font-weight: 500;
+    white-space: nowrap;
 }
 
 .dataset-details {
@@ -511,27 +753,48 @@ div.notes.embedded-content {
     margin-left: 20px;
 }
 
+/* 30px of padding per cell was pushing this table off the page; Atlas's
+   density for a key/value list is closer to 12px. */
 .additional-info-table td,
 .additional-info-table th {
-    padding: 30px;
-    border: 1px solid #ddd;
+    padding: 12px 14px;
+    border: 1px solid var(--spark-line);
+    font-size: 14px;
+    vertical-align: top;
 }
 
 a {
-    color: #000000;
+    color: inherit;
 }
 
+a:hover {
+    color: var(--spark-accent-text);
+}
+
+/* Atlas sets headings in Space Grotesk at mixed case with tight tracking.
+   Blanket uppercase + 20px of padding on every heading level was fighting
+   both. Section eyebrows that DO want uppercase opt in via --spark-mono. */
 h6, .h6, h5, .h5, h4, .h4, h3, .h3, h2, .h2, h1, .h1 {
-    text-transform: uppercase;
-    font-family: "Plus Jakarta Sans", sans-serif;
-    padding: 20px;
+    text-transform: none;
+    font-family: var(--spark-display);
+    font-weight: 700;
+    letter-spacing: -0.015em;
+    color: var(--spark-ink);
+    padding: 0;
+    margin-bottom: 14px;
 }
 
+/* Was a 4px accent underline; Atlas uses a mono eyebrow above a hairline. */
 .additional-info-header {
-    text-decoration: underline;
-    text-decoration-color: #00A99E;
-    text-underline-offset: 10px;
-    text-decoration-thickness: 4px;
+    font-family: var(--spark-mono);
+    font-size: 10.5px;
+    font-weight: 500;
+    letter-spacing: 0.13em;
+    text-transform: uppercase;
+    color: var(--spark-faint);
+    text-decoration: none;
+    padding-bottom: 11px;
+    border-bottom: 1px solid var(--spark-line);
 }
 
 .context-info .description {
@@ -544,21 +807,39 @@ h6, .h6, h5, .h5, h4, .h4, h3, .h3, h2, .h2, h1, .h1 {
 }
 
 .org-heading {
-    color: #00A99E;
+    color: var(--spark-faint);
+    font-family: var(--spark-mono);
+    font-size: 10.5px;
+    font-weight: 500;
+    letter-spacing: 0.13em;
+    text-transform: uppercase;
     padding-left: 0px;
-    padding-bottom: 10px;
+    padding-bottom: 8px;
+    margin-bottom: 0;
 }
 
 .project-desc-heading {
-    color: #00A99E;
+    color: var(--spark-faint);
+    font-family: var(--spark-mono);
+    font-size: 10.5px;
+    font-weight: 500;
+    letter-spacing: 0.13em;
+    text-transform: uppercase;
     padding-left: 0px;
-    padding-bottom: 10px;
+    padding-bottom: 8px;
+    margin-bottom: 0;
 }
 
 .timeframe-heading {
-    color: #00A99E;
+    color: var(--spark-faint);
+    font-family: var(--spark-mono);
+    font-size: 10.5px;
+    font-weight: 500;
+    letter-spacing: 0.13em;
+    text-transform: uppercase;
     padding-left: 0px;
-    padding-bottom: 10px;
+    padding-bottom: 8px;
+    margin-bottom: 0;
 }
 
 .org-title {
@@ -570,34 +851,40 @@ h6, .h6, h5, .h5, h4, .h4, h3, .h3, h2, .h2, h1, .h1 {
     padding-top: 10px;
     padding-bottom: 10px;
     font-size: 13px;
-    font-family: "Plus Jakarta Sans", sans-serif;
+    font-family: var(--spark-display);
 }
 
 .project-desc {
     padding-top: 10px;
     padding-bottom: 10px;
     font-size: 13px;
-    font-family: "Plus Jakarta Sans", sans-serif;
+    font-family: var(--spark-display);
 }
 
 .data-resources-heading {
-    text-decoration: underline;
-    text-decoration-color: #00A99E;
-    text-underline-offset: 10px;
-    text-decoration-thickness: 4px;
+    font-family: var(--spark-display);
+    font-size: 20px;
+    font-weight: 700;
+    letter-spacing: -0.015em;
+    text-decoration: none;
+    padding-bottom: 12px;
+    border-bottom: 1px solid var(--spark-line);
 }
 
+/* Atlas's primary action: solid accent, 7px radius. */
 .btn-primary {
-    font-family: "Plus Jakarta Sans", sans-serif;
-    color: #00A99E;
-    background-color: #FFFFFF;
-    border-color: #00A99E;
-    border-radius: 20px;
+    font-family: var(--spark-display);
+    font-weight: 600;
+    color: #FFFFFF;
+    background-color: var(--spark-accent-text);
+    border-color: var(--spark-accent-text);
+    border-radius: 7px;
 }
 
 .btn-primary:hover,
 .btn-primary:active {
-    background-color: #00A99E;
+    background-color: var(--spark-accent-deep);
+    border-color: var(--spark-accent-deep);
     color: #FFFFFF;
 }
 
@@ -613,7 +900,7 @@ h6, .h6, h5, .h5, h4, .h4, h3, .h3, h2, .h2, h1, .h1 {
 }
 
 .nav-link, .page-header .nav-tabs li a {
-    color: #00A99E;
+    color: var(--spark-accent-text);
 }
 
 /* Pagination Controls Styles */
@@ -625,9 +912,9 @@ h6, .h6, h5, .h5, h4, .h4, h3, .h3, h2, .h2, h1, .h1 {
 }
 
 .pagination-controls button {
-    font-family: "Plus Jakarta Sans", sans-serif;
+    font-family: var(--spark-display);
     font-size: 14px;
-    color: #00A99E;
+    color: var(--spark-accent-text);
     background-color: transparent;
     padding: 8px 15px;
     margin: 0 5px;
@@ -635,13 +922,29 @@ h6, .h6, h5, .h5, h4, .h4, h3, .h3, h2, .h2, h1, .h1 {
     transition: background-color 0.3s, color 0.3s;
 }
 
+/* This is an <a>, not a <button>, so it misses the .pagination-controls
+   button rules above and needs its own padding and colour. */
 .show-more-btn {
-    border: 2px solid #00A99E;
-    border-radius: 20px;
+    border: 1px solid var(--spark-line-strong);
+    border-radius: 7px;
+    font-family: var(--spark-display);
+    font-weight: 600;
+    font-size: 13.5px;
+    color: var(--spark-ink);
+    padding: 10px 20px;
+    text-decoration: none;
+    transition: background-color 0.18s, color 0.18s, border-color 0.18s;
+}
+
+.show-more-btn:hover {
+    background-color: var(--spark-accent-text);
+    border-color: var(--spark-accent-text);
+    color: #FFFFFF;
+    text-decoration: none;
 }
 
 .pagination-controls button:hover {
-    background-color: #00A99E;
+    background-color: var(--spark-accent-text);
     color: #FFFFFF;
 }
 
@@ -659,4 +962,80 @@ h6, .h6, h5, .h5, h4, .h4, h3, .h3, h2, .h2, h1, .h1 {
 
 .next-btn::before {
     margin-left: 5px;
+}
+
+/* Topic pills on the dataset page sidebar. Same chip primitive as the homepage
+   popular-tags rail, so a topic looks the same wherever it appears. */
+.topic-pills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.topic-pill {
+    display: inline-block;
+    font-family: var(--spark-mono);
+    font-size: 11.5px;
+    letter-spacing: 0.02em;
+    line-height: 1.3;
+    padding: 6px 12px;
+    border-radius: 20px;
+    border: 1px solid var(--spark-line-strong);
+    background: var(--spark-bg);
+    color: var(--spark-muted);
+    text-decoration: none;
+}
+
+.topic-pill:hover, .topic-pill:focus-visible {
+    background: var(--spark-accent-text);
+    border-color: var(--spark-accent-text);
+    color: #fff;
+    text-decoration: none;
+}
+
+
+/* ── Keyboard focus ─────────────────────────────────────────────────────────
+   Every interactive element this theme restyles needs a visible focus ring, or
+   restyling silently removes the UA default and the page becomes unusable by
+   keyboard. :focus-visible (not :focus) so a mouse click doesn't leave a ring
+   behind. The 2px offset keeps the ring clear of the element's own border. */
+.topic-tile:focus-visible,
+.topic-pill:focus-visible,
+.view-button:focus-visible,
+.show-more-btn:focus-visible,
+.home-card a:focus-visible,
+.homepage .module-search .tags .tag:focus-visible,
+.tab:focus-visible,
+.masthead .main-navbar ul li a:focus-visible,
+.toolbar .breadcrumb a:focus-visible {
+    outline: 2px solid var(--spark-accent-text);
+    outline-offset: 2px;
+    border-radius: 4px;
+}
+
+/* Hover and keyboard focus should look the same on the card-like targets. */
+.topic-tile:focus-visible {
+    border-color: var(--spark-line-strong);
+}
+
+.view-button:focus-visible,
+.show-more-btn:focus-visible {
+    background-color: var(--spark-accent-text);
+    border-color: var(--spark-accent-text);
+    color: #FFFFFF;
+    text-decoration: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .home-card,
+    .topic-tile,
+    .view-button,
+    .show-more-btn,
+    .tab {
+        transition: none;
+    }
+    .home-card:hover,
+    .topic-tile:hover {
+        transform: none;
+    }
 }

--- a/ckanext/spark/templates/package/read_base.html
+++ b/ckanext/spark/templates/package/read_base.html
@@ -7,3 +7,8 @@
 {% block package_license %}
   {% endblock %}
 
+{% block secondary_content %}
+  {{ super() }}
+  {% snippet "snippets/topics_list.html", groups=pkg.groups %}
+{% endblock %}
+

--- a/ckanext/spark/templates/snippets/layout.html
+++ b/ckanext/spark/templates/snippets/layout.html
@@ -88,22 +88,22 @@
           </div>
         </section>
 
+        {# The full taxonomy, not a sample: every topic shows even at zero
+           datasets, so the shape of the collection is legible while it fills. #}
         <section class="tab-content" id="tab-topics">
-          <div class="home-card-container">
-            {% for topic in h.spark_groups(limit=6) %}
-              <article class="home-card">
-                <div class="home-card-content">
-                  <a href="{{ h.url_for('group.read', id=topic.name) }}">
-                    {{ topic.display_name or topic.title or topic.name }}
-                  </a>
-                </div>
-              </article>
-            {% else %}
-              <p class="empty">No topics are available yet.</p>
+          <div class="topic-grid">
+            {% for topic in h.spark_topics() %}
+              <a class="topic-tile{{ ' is-empty' if not topic.count }}"
+                 href="{{ h.url_for('group.read', id=topic.name) }}">
+                <span class="topic-tile-name">{{ topic.title }}</span>
+                <span class="topic-tile-count">
+                  {{ topic.count }} {{ 'dataset' if topic.count == 1 else 'datasets' }}
+                </span>
+              </a>
             {% endfor %}
           </div>
           <div class="pagination-controls">
-            <a href="{{ h.url_for('group.index') }}" class="show-more-btn">View all topics</a>
+            <a href="{{ h.url_for('group.index') }}" class="show-more-btn">Browse all topics</a>
           </div>
         </section>
       </div>

--- a/ckanext/spark/templates/snippets/topics_list.html
+++ b/ckanext/spark/templates/snippets/topics_list.html
@@ -1,0 +1,21 @@
+{#
+Topics a dataset is filed under, for the dataset page sidebar.
+
+CKAN doesn't surface a dataset's groups on the read page by default (they live
+on a separate /dataset/groups/<id> tab), so a dataset would otherwise never
+show its own topic. Renders nothing when a dataset has no topics yet.
+#}
+{% if groups %}
+  <div class="module module-narrow module-shallow context-info">
+    <section class="module-content">
+      <h5 class="org-heading">{{ _('Topics') }}</h5>
+      <div class="topic-pills">
+        {% for group in groups %}
+          <a class="topic-pill" href="{{ h.url_for('group.read', id=group.name) }}">
+            {{ group.display_name or group.title or group.name }}
+          </a>
+        {% endfor %}
+      </div>
+    </section>
+  </div>
+{% endif %}

--- a/ckanext/spark/tests/test_helpers.py
+++ b/ckanext/spark/tests/test_helpers.py
@@ -1,6 +1,9 @@
 """Tests for Data@Spark template helpers."""
 
+import re
+
 import ckanext.spark.helpers as helpers
+import ckanext.spark.topics as topics
 
 
 def test_format_date_formats_iso_timestamp():
@@ -46,14 +49,86 @@ def test_featured_datasets_filters_featured_tag(monkeypatch):
     ]
 
 
-def test_groups_accepts_an_optional_limit(monkeypatch):
+def _stub_topic_search(monkeypatch, facet_items, calls=None):
+    """Point package_search at a canned `groups` facet response."""
+
+    def package_search(context, data_dict):
+        if calls is not None:
+            calls.append((context, data_dict))
+        return {
+            "count": 0,
+            "results": [],
+            "search_facets": {"groups": {"items": facet_items}},
+        }
+
+    monkeypatch.setattr(helpers.toolkit, "get_action", lambda action: package_search)
+
+
+def test_topics_returns_the_whole_taxonomy_in_order(monkeypatch):
+    _stub_topic_search(monkeypatch, [])
+
+    result = helpers.topics()
+
+    assert [topic["name"] for topic in result] == [
+        name for name, _title in topics.SPARK_TOPICS
+    ]
+    # A topic with no datasets still appears -- the taxonomy is the point, not
+    # just the datasets currently in it.
+    assert all(topic["count"] == 0 for topic in result)
+
+
+def test_topics_merges_facet_counts_by_group_name(monkeypatch):
+    _stub_topic_search(
+        monkeypatch,
+        [
+            {"name": "education-learning", "count": 4},
+            {"name": "law-civil-rights", "count": 1},
+            # A group that isn't part of the taxonomy must not leak in.
+            {"name": "some-other-group", "count": 9},
+        ],
+    )
+
+    counts = {topic["name"]: topic["count"] for topic in helpers.topics()}
+
+    assert counts["education-learning"] == 4
+    assert counts["law-civil-rights"] == 1
+    assert counts["housing-urban-development"] == 0
+    assert "some-other-group" not in counts
+
+
+def test_topics_pins_the_facet_limit(monkeypatch):
+    """The count query must not inherit a facet cap from site config.
+
+    CKAN takes facet.limit from `search.facets.limit` (default 50), so all 11
+    topics come back today. Pinning -1 keeps that true if the config is lowered
+    or the taxonomy outgrows it, instead of quietly dropping the rarest topics.
+    """
     calls = []
+    _stub_topic_search(monkeypatch, [], calls)
 
-    def group_list(context, data_dict):
-        calls.append((context, data_dict))
-        return []
+    helpers.topics()
 
-    monkeypatch.setattr(helpers.toolkit, "get_action", lambda action: group_list)
+    (_context, data_dict), = calls
+    assert data_dict["facet.limit"] == -1
+    assert data_dict["rows"] == 0
 
-    assert helpers.groups(limit=6) == []
-    assert calls == [({}, {"all_fields": True, "limit": 6})]
+
+def test_topics_survives_an_empty_search_index(monkeypatch):
+    """A fresh site returns no search_facets key at all."""
+
+    monkeypatch.setattr(
+        helpers.toolkit,
+        "get_action",
+        lambda action: lambda context, data_dict: {"count": 0, "results": []},
+    )
+
+    assert len(helpers.topics()) == len(topics.SPARK_TOPICS)
+
+
+def test_topic_names_are_unique_and_url_safe():
+    names = [name for name, _title in topics.SPARK_TOPICS]
+
+    assert len(names) == len(set(names)), "a duplicate name would collide in CKAN"
+    for name in names:
+        # CKAN group names: lowercase alphanumerics, - and _, at least 2 chars.
+        assert re.fullmatch(r"[a-z0-9_-]{2,100}", name), name

--- a/ckanext/spark/topics.py
+++ b/ckanext/spark/topics.py
@@ -1,0 +1,39 @@
+"""The Data@Spark topic taxonomy.
+
+This is the rolled-up ("academic disciplines") list of ~11 categories, NOT the
+detailed 40-50 item breakdown. CKAN's topic model is flat, so only the top level
+is representable -- the detailed list would need a hierarchy CKAN doesn't have.
+
+Kept deliberately identical to `SPARK_TOPICS` in the Atlas project gallery
+(spark-portfolio/hub/lib/data.ts) so a dataset and a project describe themselves
+with the same words. If that list changes, change this one in the same PR.
+
+Topics are modelled as CKAN *groups*, not free tags: groups are flat (so they
+fit the constraint), but unlike tags they are a controlled vocabulary, they get
+a browsable page each, and CKAN already facets search on them. The `featured`
+tag is unrelated -- that's a flag, not a topic.
+
+Each entry is (name, title). `name` is the CKAN group name: it is the URL
+(/group/<name>) and the key datasets are joined on, so it is written down
+explicitly rather than derived from the title. Deriving it would mean that
+retitling a topic silently changes its URL and orphans every dataset filed
+under the old one. Retitle freely; never edit a `name`.
+"""
+
+SPARK_TOPICS = [
+    ("housing-urban-development", "Housing & Urban Development"),
+    ("government-politics-public-policy", "Government, Politics & Public Policy"),
+    ("criminal-justice-public-safety", "Criminal Justice & Public Safety"),
+    ("education-learning", "Education & Learning"),
+    ("immigration-community-social-services", "Immigration, Community & Social Services"),
+    ("business-economy-work", "Business, Economy & Work"),
+    ("health-medicine-wellbeing", "Health, Medicine & Wellbeing"),
+    ("environment-sustainability", "Environment & Sustainability"),
+    ("law-civil-rights", "Law & Civil Rights"),
+    ("media-technology-communication", "Media, Technology & Communication"),
+    ("arts-culture-humanities", "Arts, Culture & Humanities"),
+]
+
+# name -> title, for turning a search facet (which reports group names) back
+# into something displayable.
+TITLES = dict(SPARK_TOPICS)

--- a/contrib/init-datastore.sql
+++ b/contrib/init-datastore.sql
@@ -1,0 +1,6 @@
+-- Datastore database + read-only role, created on the Postgres container's
+-- first boot. CKAN's datastore plugin refuses to start without both, and the
+-- read URL must be a genuinely separate role or a SQL-injected datastore query
+-- could reach the main CKAN tables.
+CREATE ROLE datastore_ro NOSUPERUSER NOCREATEDB NOCREATEROLE LOGIN PASSWORD 'pass';
+CREATE DATABASE datastore OWNER ckan ENCODING 'utf-8';

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,90 @@
+# Local development stack for the Data@Spark theme.
+#
+# Deliberately self-contained rather than reusing infra-public-data-portal's
+# compose: that one pins CKAN 2.10 with a Solr 8 image (and an .env claiming
+# 2.9.7), and this theme was rehabilitated for CKAN 2.11 -- Solr 8 won't serve a
+# 2.11 schema. It is also a half-finished 2024 Kubernetes migration, so changing
+# it to run a theme locally would mean editing something mid-refactor.
+#
+# This is for local work only. It is not a deployment: the secrets below are
+# fixed test values, and the site is served over plain HTTP on localhost.
+#
+#   docker compose -f docker-compose.dev.yml up -d
+#   docker compose -f docker-compose.dev.yml exec ckan ckan -c $CKAN_INI spark init-topics
+#   open http://localhost:5000
+#
+# The repo is bind-mounted, so template and CSS edits show up on reload.
+
+name: ckanext-spark-dev
+
+services:
+  ckan:
+    image: ckan/ckan-dev:2.11
+    # The official CKAN images are published amd64-only, so on Apple Silicon
+    # they run under emulation. Slower to boot, but it's the same image CI and
+    # the server use -- worth more than a fast locally-built variant.
+    platform: linux/amd64
+    depends_on:
+      db:
+        condition: service_healthy
+      solr:
+        condition: service_started
+      redis:
+        condition: service_started
+    ports:
+      - "5000:5000"
+    # The image's install_src.sh only runs at BUILD time, and /docker-entrypoint.d
+    # runs after prerun.py has already tried (and failed) to load the plugin. So a
+    # bind-mounted extension has to be pip-installed here, ahead of the start
+    # script, or CKAN boots with "Plugin 'spark' not found" and restart-loops.
+    # Editable install + bind mount means template and Python edits stay live.
+    command: >
+      bash -c "pip install -e /srv/app/src_extensions/ckanext-spark &&
+               /srv/app/start_ckan_development.sh"
+    environment:
+      CKAN_SQLALCHEMY_URL: postgresql://ckan:pass@db/ckan
+      CKAN_DATASTORE_WRITE_URL: postgresql://ckan:pass@db/datastore
+      CKAN_DATASTORE_READ_URL: postgresql://datastore_ro:pass@db/datastore
+      CKAN_SOLR_URL: http://solr:8983/solr/ckan
+      CKAN_REDIS_URL: redis://redis:6379/0
+      CKAN_SITE_URL: http://localhost:5000
+      CKAN__PLUGINS: envvars image_view datatables_view datastore spark
+      CKAN___BEAKER__SESSION__SECRET: local-dev-not-a-secret
+      CKAN__API_TOKEN__JWT__ENCODE__SECRET: string:local-dev-not-a-secret
+      CKAN__API_TOKEN__JWT__DECODE__SECRET: string:local-dev-not-a-secret
+      CKAN_SYSADMIN_NAME: ckan_admin
+      CKAN_SYSADMIN_PASSWORD: test1234
+      CKAN_SYSADMIN_EMAIL: admin@localhost.local
+    volumes:
+      # The image expects mounted extensions under src/, and its entrypoint
+      # pip-installs anything it finds there in editable mode.
+      - .:/srv/app/src_extensions/ckanext-spark
+
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: ckan
+      POSTGRES_PASSWORD: pass
+      POSTGRES_DB: ckan
+    volumes:
+      - pg:/var/lib/postgresql/data
+      - ./contrib/init-datastore.sql:/docker-entrypoint-initdb.d/10-datastore.sql:ro
+    healthcheck:
+      # Without a healthcheck gate CKAN's entrypoint races Postgres' first-boot
+      # initdb and dies on connection refused before it ever retries.
+      test: ["CMD-SHELL", "pg_isready -U ckan"]
+      interval: 5s
+      retries: 20
+
+  solr:
+    image: ckan/ckan-solr:2.11-solr9
+    platform: linux/amd64
+    volumes:
+      - solr:/var/solr
+
+  redis:
+    image: redis:7-alpine
+
+volumes:
+  pg:
+  solr:


### PR DESCRIPTION
Two requested changes, plus the local dev stack needed to verify them.

There is nowhere to deploy to at the moment — `data.buspark.io` has been
returning Cloudflare 523 (origin unreachable) since at least 2026-07-04 and
still was today, so everything below was verified against a local CKAN 2.11.

## 1. Topic taxonomy

Adds the rolled-up *academic disciplines* list of **11 subject areas** — the
higher-level list, not the detailed 40–50 item breakdown. CKAN's topic model is
flat, so only the top level is representable.

The terms are byte-identical to `SPARK_TOPICS` in the Atlas project gallery
(`spark-portfolio/hub/lib/data.ts`), so a dataset and a project describe
themselves with the same words. **The two lists have to be changed together** —
there's a comment in each pointing at the other.

### Groups, not tags

Topics are modelled as CKAN **groups**. Groups are equally flat, so they satisfy
the same constraint free tags would, but unlike tags they are a controlled
vocabulary (no typos, no near-duplicates), they get a browsable page each, and
CKAN already facets search on them. The theme was also already pointing
"Topics" at `group.index` in both the nav and the homepage tab, so this is the
smaller change as well as the sturdier one.

The unrelated `featured` **tag** is untouched — that's a flag, not a topic.

### Names are pinned, not derived

A group's `name` is both its URL and the key datasets join on, so the
`(name, title)` pairs are written out explicitly. Deriving the slug from the
title would mean retitling a topic silently changes its URL and orphans every
dataset filed under it. Retitle freely; never edit a name.

### What's included

- `ckan spark init-topics` seeds the groups. Safe to re-run: it repairs a wrong
  title or a soft-deleted topic and leaves editor-added descriptions and images
  alone.
- The homepage **Topics** tab lists the whole taxonomy with live dataset counts,
  including topics sitting at zero, from a single faceted search.
- Datasets show their own topics on the dataset page, which CKAN otherwise only
  exposes on a separate `/dataset/groups/<id>` tab.

### Known gap

Assigning a topic is a **second step after creating a dataset**: CKAN 2.11's
dataset form has an Organization selector but no group selector. So a dataset
can be created with no topic and nothing complains. If datasets start landing
untagged, an 11-way picker on the form is the fix — happy to add it here or
follow up.

## 2. Theme

Re-skinned on the Atlas gallery's tokens (`#0fa392`, Space Grotesk / IBM Plex
Sans / IBM Plex Mono, `#16191c` ink, hairline greys) so the two properties read
as one product. **No spinning logo.**

The full-bleed teal hero is replaced by Atlas's white intro band. That forced a
related fix: the heading, tagline, search heading and intro copy were all
*white-on-teal* and would have become white-on-white.

### Accessibility — against the criteria in #4

- **Every text colour now meets WCAG AA (4.5:1).** Atlas's `#0fa392` is only
  3.15:1 on white, so it's kept for borders and the active-tab indicator (which
  need 3:1 under 1.4.11) while a darkened `#0b7f72` carries accent text and
  accent-filled buttons at 4.89:1. The old `#9a9a9a` eyebrow grey was 2.81:1 and
  is now 5.05:1. Worth flagging: matching Atlas exactly would have *inherited*
  its contrast failures.
- Adds visible `:focus-visible` rings to every control the theme restyles —
  restyling them had been silently removing the UA default.
- Honours `prefers-reduced-motion`.
- The homepage module no longer renders **completely blank without JavaScript**;
  the first tab panel is shown from CSS. Full no-JS support and accessible tab
  semantics stay in #4.

Also fixes two latent layout bugs: a fixed `250px` grid gutter that overflowed
anything narrower than a wide desktop, and dataset cards laid out with
`space-between`, which never aligned on a short final row.

This is partial progress on #4, not a close — the `TBD`/hard-coded-2023 content,
the `VIEW` dropdown, and the footer links are all untouched.

## 3. Local development

`docker-compose.dev.yml` runs CKAN 2.11 with the repo bind-mounted:

```bash
docker compose -f docker-compose.dev.yml up -d
docker compose -f docker-compose.dev.yml exec ckan ckan -c "$CKAN_INI" spark init-topics
open http://localhost:5000     # ckan_admin / test1234
```

Deliberately separate from `infra-public-data-portal`, whose compose pins CKAN
2.10 with a Solr **8** image (and an `.env` claiming 2.9.7) and is a
half-finished Kubernetes migration — Solr 8 cannot serve a 2.11 schema.
Deployment still comes from that repo, not this one.

Two things that needed solving and are worth knowing: the official CKAN images
are amd64-only (so `platform: linux/amd64` on Apple Silicon), and the image's
`install_src.sh` only runs at **build** time while `/docker-entrypoint.d` runs
*after* `prerun.py` has already failed — so a bind-mounted extension has to be
pip-installed from `command:` ahead of the start script.

## Verification

All against a local CKAN 2.11, not just asserted:

- `init-topics` created all 11 topics; a second run reported `ok` for all 11.
- Deliberately retitled one topic and soft-deleted another — the re-run repaired
  exactly those two and left the other nine alone.
- Seeded datasets produce correct homepage counts, including `1 dataset`
  singular vs `2 datasets`, with empty topics greyed out.
- Topic pills render on the dataset page; `/group/` and each topic page 200.
- 11/11 tests pass.
- Contrast ratios computed for every foreground/background pair in the palette.

One correction worth recording: an earlier draft of this work claimed CKAN
defaults `facet.limit` to 10 and that 11 topics would silently lose one. That's
wrong — the query limit comes from `search.facets.limit` (default **50**); the
10 is `search.facets.default`, a UI display cap that never reaches this query.
`facet.limit: -1` is kept as cheap hardening against that config being lowered,
and the code and test now say so.

Refs #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012badxi5vu4W6ku99EucbRE