### PR TITLE
README: document the ckan-docker deployment pin and bump procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,35 @@ This stack is for local work only — the credentials in it are fixed test value
 and it serves plain HTTP on localhost. It is deliberately separate from
 `infra-public-data-portal`, whose compose is a half-finished Kubernetes
 migration still pinned to CKAN 2.10 and Solr 8 (Solr 8 cannot serve a 2.11
-schema). Deployment still comes from that repository, not this one.
+schema).
+
+## Deployment
+
+**Making a skin or taxonomy change here does not, by itself, deploy anything.**
+The live Data@Spark image is built by `BU-Spark/ckan-docker`
+(`data-at-spark/Dockerfile`), which installs this extension from an exact,
+hardcoded Git commit:
+
+```dockerfile
+ARG CKANEXT_SPARK_COMMIT=<some commit sha>
+```
+
+That pin is deliberate, not an oversight — the same reasoning `ckan-docker`
+uses for its other pinned dependencies applies here: a branch name is not a
+pin, and a floating reference would mean some *other*, unrelated change could
+silently drag in unreviewed theme code with no corresponding change in
+`ckan-docker`'s own history.
+
+So after merging a PR here, someone has to go update that pin by hand:
+
+1. In `ckan-docker`, update `CKANEXT_SPARK_COMMIT` in both
+   `data-at-spark/Dockerfile` and the default in `data-at-spark/compose.yml`
+   to this repo's new `main` commit SHA.
+2. Push that change to `ckan-docker`'s `master` — that push is what actually
+   triggers the build, publish, and (for `int`) automatic redeploy. Merging
+   here does not.
+
+See `ckan-docker`'s `data-at-spark/README.md` for the full procedure.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Adds a `## Deployment` section explaining that `ckan-docker` pins this extension to an exact commit SHA (deliberately, not a branch), and spells out the manual bump procedure -- merging here doesn't deploy anything by itself.
- Someone editing the skin/taxonomy may not know `ckan-docker` exists at all, so this needs to live here too, not just in `ckan-docker`'s own README.
- Also fixes a stale claim that `infra-public-data-portal` is where deployment comes from -- it's actually `ckan-docker` now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018vT1anFoAEHRNje8KiEvcL