### PR TITLE
Temporarily disable the live homepage topic count

### DIFF
--- a/ckanext/spark/helpers.py
+++ b/ckanext/spark/helpers.py
@@ -30,34 +30,17 @@ def popular_datasets():
 def topics():
     """Return the canonical topic taxonomy, each with its live dataset count.
 
-    Always returns all of SPARK_TOPICS in taxonomy order, including topics with
-    no datasets yet -- the point of a fixed taxonomy is that the shape of it is
-    visible before it's full. Counts come from one faceted search rather than a
-    query per topic.
+    The live count is temporarily disabled -- see ckanext-spark#7. The
+    `package_search` facet query this used to run on every homepage load (with
+    no caching) coincided with the CKAN container becoming unhealthy and its
+    uWSGI workers thrashing on int within about a minute of deploy, under only
+    a single visitor's traffic. Root cause wasn't confirmed before rollback,
+    but this is the one thing this PR added to every homepage request, so it's
+    the first suspect to remove. Always returns all of SPARK_TOPICS in
+    taxonomy order with count 0 until #7 restores this with a fix (caching, a
+    cheaper query, or confirmation this wasn't actually the cause).
     """
-    result = toolkit.get_action("package_search")(
-        {},
-        {
-            "rows": 0,
-            "facet.field": ["groups"],
-            # Defensive, not a bugfix: CKAN feeds facet.limit from
-            # `search.facets.limit`, which defaults to 50, so the 11 topics fit
-            # today. Pinning -1 means the homepage can't start silently dropping
-            # the least-used topics if someone lowers that config, or if the
-            # taxonomy grows past it. (The other CKAN setting,
-            # `search.facets.default` = 10, is a UI display cap and never
-            # reaches this query.)
-            "facet.limit": -1,
-        },
-    )
-    # Missing on a brand-new site with an empty index.
-    counts = result.get("search_facets", {}).get("groups", {}).get("items", [])
-    counts = {item["name"]: item["count"] for item in counts}
-
-    return [
-        {"name": name, "title": title, "count": counts.get(name, 0)}
-        for name, title in SPARK_TOPICS
-    ]
+    return [{"name": name, "title": title, "count": 0} for name, title in SPARK_TOPICS]
 
 
 def format_date(value):

--- a/ckanext/spark/tests/test_helpers.py
+++ b/ckanext/spark/tests/test_helpers.py
@@ -49,24 +49,7 @@ def test_featured_datasets_filters_featured_tag(monkeypatch):
     ]
 
 
-def _stub_topic_search(monkeypatch, facet_items, calls=None):
-    """Point package_search at a canned `groups` facet response."""
-
-    def package_search(context, data_dict):
-        if calls is not None:
-            calls.append((context, data_dict))
-        return {
-            "count": 0,
-            "results": [],
-            "search_facets": {"groups": {"items": facet_items}},
-        }
-
-    monkeypatch.setattr(helpers.toolkit, "get_action", lambda action: package_search)
-
-
-def test_topics_returns_the_whole_taxonomy_in_order(monkeypatch):
-    _stub_topic_search(monkeypatch, [])
-
+def test_topics_returns_the_whole_taxonomy_in_order():
     result = helpers.topics()
 
     assert [topic["name"] for topic in result] == [
@@ -74,55 +57,28 @@ def test_topics_returns_the_whole_taxonomy_in_order(monkeypatch):
     ]
     # A topic with no datasets still appears -- the taxonomy is the point, not
     # just the datasets currently in it.
-    assert all(topic["count"] == 0 for topic in result)
+    assert all(topic["title"] for topic in result)
 
 
-def test_topics_merges_facet_counts_by_group_name(monkeypatch):
-    _stub_topic_search(
-        monkeypatch,
-        [
-            {"name": "education-learning", "count": 4},
-            {"name": "law-civil-rights", "count": 1},
-            # A group that isn't part of the taxonomy must not leak in.
-            {"name": "some-other-group", "count": 9},
-        ],
-    )
+def test_topics_live_count_is_temporarily_disabled(monkeypatch):
+    """See ckanext-spark#7.
 
-    counts = {topic["name"]: topic["count"] for topic in helpers.topics()}
-
-    assert counts["education-learning"] == 4
-    assert counts["law-civil-rights"] == 1
-    assert counts["housing-urban-development"] == 0
-    assert "some-other-group" not in counts
-
-
-def test_topics_pins_the_facet_limit(monkeypatch):
-    """The count query must not inherit a facet cap from site config.
-
-    CKAN takes facet.limit from `search.facets.limit` (default 50), so all 11
-    topics come back today. Pinning -1 keeps that true if the config is lowered
-    or the taxonomy outgrows it, instead of quietly dropping the rarest topics.
+    The `package_search` facet query this used to run on every homepage load
+    coincided with int becoming unhealthy shortly after this shipped. Root
+    cause wasn't confirmed, but this was the one thing added to every
+    homepage request, so it's disabled pending investigation. This test pins
+    that: topics() must not touch package_search at all right now, and every
+    count must read 0. Update/remove this once #7 restores a fix.
     """
-    calls = []
-    _stub_topic_search(monkeypatch, [], calls)
 
-    helpers.topics()
+    def fail(*_args, **_kwargs):
+        raise AssertionError("topics() must not call get_action while disabled")
 
-    (_context, data_dict), = calls
-    assert data_dict["facet.limit"] == -1
-    assert data_dict["rows"] == 0
+    monkeypatch.setattr(helpers.toolkit, "get_action", fail)
 
+    result = helpers.topics()
 
-def test_topics_survives_an_empty_search_index(monkeypatch):
-    """A fresh site returns no search_facets key at all."""
-
-    monkeypatch.setattr(
-        helpers.toolkit,
-        "get_action",
-        lambda action: lambda context, data_dict: {"count": 0, "results": []},
-    )
-
-    assert len(helpers.topics()) == len(topics.SPARK_TOPICS)
+    assert all(topic["count"] == 0 for topic in result)
 
 
 def test_topic_names_are_unique_and_url_safe():


### PR DESCRIPTION
## Summary
- Disables \`spark_topics()\`'s per-request \`package_search\` Solr facet call, which coincided with int becoming unhealthy shortly after #5 deployed. Everything else from #5 (taxonomy, CLI, skin) stays.
- Files #7 for the real fix (confirm root cause, cache or cheapen the query, restore the live count).

## Test plan
- [x] \`python3 -m py_compile\` on both changed files
- [ ] Not run against a live CKAN instance -- next step is bumping ckan-docker's pin and watching int redeploy stay healthy under real traffic

Refs #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018vT1anFoAEHRNje8KiEvcL