### PR TITLE
Cache all four homepage searches and restore the live topic count (#7)

### DIFF
--- a/ckanext/spark/helpers.py
+++ b/ckanext/spark/helpers.py
@@ -1,10 +1,28 @@
 """Template helpers for the Data@Spark theme."""
 
+import logging
+import time
 from datetime import datetime
 
 from ckan.plugins import toolkit
 
 from ckanext.spark.topics import SPARK_TOPICS
+
+log = logging.getLogger(__name__)
+
+# How long a topic count may be stale. Topics are created by hand and datasets
+# are added in batches, so a homepage tile reading one dataset behind for a
+# minute costs nothing; taking Solr off the per-request path is worth much more.
+TOPIC_COUNT_TTL_SECONDS = 60
+
+# (fetched_at_monotonic, {group_name: count}). Module-level, so each uWSGI
+# worker keeps its own copy -- with a handful of workers that is still at most a
+# few queries per TTL instead of one per request. Deliberately not Redis: a
+# shared cache would be another moving part and another thing that can be down,
+# for a value this cheap to recompute. Assignment of the whole tuple is atomic
+# under the GIL, so a concurrent refresh costs a duplicate query, never a torn
+# read.
+_topic_counts_cache = (None, {})
 
 
 def _datasets(**params):
@@ -27,20 +45,71 @@ def popular_datasets():
     return _datasets(sort="views_recent desc")
 
 
-def topics():
-    """Return the canonical topic taxonomy, each with its live dataset count.
+def _refresh_topic_counts():
+    """Ask Solr how many datasets sit in each group. One query, no dataset bodies."""
+    result = toolkit.get_action("package_search")(
+        {},
+        {
+            "rows": 0,
+            "facet.field": ["groups"],
+            # Measured at 304 datasets: identical to facet.limit=50 (27.8ms vs
+            # 26.6ms median), because the cost is bounded by the number of
+            # groups, not the number of datasets. Pinning -1 means the homepage
+            # can't silently start dropping the least-used topics if
+            # `search.facets.limit` is lowered or the taxonomy outgrows it.
+            "facet.limit": -1,
+        },
+    )
+    # Missing on a brand-new site with an empty index.
+    items = result.get("search_facets", {}).get("groups", {}).get("items", [])
+    return {item["name"]: item["count"] for item in items}
 
-    The live count is temporarily disabled -- see ckanext-spark#7. The
-    `package_search` facet query this used to run on every homepage load (with
-    no caching) coincided with the CKAN container becoming unhealthy and its
-    uWSGI workers thrashing on int within about a minute of deploy, under only
-    a single visitor's traffic. Root cause wasn't confirmed before rollback,
-    but this is the one thing this PR added to every homepage request, so it's
-    the first suspect to remove. Always returns all of SPARK_TOPICS in
-    taxonomy order with count 0 until #7 restores this with a fix (caching, a
-    cheaper query, or confirmation this wasn't actually the cause).
+
+def topic_counts():
+    """Group-name -> dataset count, cached for TOPIC_COUNT_TTL_SECONDS.
+
+    See ckanext-spark#7: an uncached version of this query ran on every homepage
+    load and coincided with the int container going unhealthy. Root cause was
+    never confirmed, and local measurement at 304 datasets puts this query at
+    27.8ms median -- indistinguishable from the three `package_search` calls the
+    homepage already made (25-27ms each). So this cache is not a proven fix for
+    that incident; it removes the query from the hot path so it cannot be the
+    cause of the next one, and that is all it claims.
+
+    A failed refresh serves the previous counts rather than raising. Solr being
+    slow or down should degrade the homepage's topic tiles to stale-or-zero, not
+    500 the whole page -- which is the failure mode #7 actually cared about.
     """
-    return [{"name": name, "title": title, "count": 0} for name, title in SPARK_TOPICS]
+    global _topic_counts_cache
+    fetched_at, counts = _topic_counts_cache
+    now = time.monotonic()
+
+    if fetched_at is not None and now - fetched_at < TOPIC_COUNT_TTL_SECONDS:
+        return counts
+
+    try:
+        counts = _refresh_topic_counts()
+    except Exception:
+        # Keep serving the last good counts (or {} on the very first call) and
+        # back off for a full TTL so a struggling Solr isn't retried per request.
+        log.warning("Topic count refresh failed; serving stale counts", exc_info=True)
+
+    _topic_counts_cache = (now, counts)
+    return counts
+
+
+def topics():
+    """Return the canonical topic taxonomy, each with its dataset count.
+
+    Always returns all of SPARK_TOPICS in taxonomy order, including topics with
+    no datasets yet -- the point of a fixed taxonomy is that the shape of it is
+    visible before it's full. Counts are cached; see topic_counts().
+    """
+    counts = topic_counts()
+    return [
+        {"name": name, "title": title, "count": counts.get(name, 0)}
+        for name, title in SPARK_TOPICS
+    ]
 
 
 def format_date(value):

--- a/ckanext/spark/helpers.py
+++ b/ckanext/spark/helpers.py
@@ -10,19 +10,76 @@ from ckanext.spark.topics import SPARK_TOPICS
 
 log = logging.getLogger(__name__)
 
-# How long a topic count may be stale. Topics are created by hand and datasets
-# are added in batches, so a homepage tile reading one dataset behind for a
-# minute costs nothing; taking Solr off the per-request path is worth much more.
-TOPIC_COUNT_TTL_SECONDS = 60
+# How long homepage search results may be stale. Everything cached here is a
+# "what's here lately" summary, so a tile reading a minute behind costs nothing;
+# taking Solr off the per-request path is worth much more.
+HOMEPAGE_CACHE_TTL_SECONDS = 60
 
-# (fetched_at_monotonic, {group_name: count}). Module-level, so each uWSGI
-# worker keeps its own copy -- with a handful of workers that is still at most a
-# few queries per TTL instead of one per request. Deliberately not Redis: a
-# shared cache would be another moving part and another thing that can be down,
-# for a value this cheap to recompute. Assignment of the whole tuple is atomic
-# under the GIL, so a concurrent refresh costs a duplicate query, never a torn
-# read.
-_topic_counts_cache = (None, {})
+# Back-compat alias: the topic-count TTL was named separately before the other
+# three homepage searches were cached too.
+TOPIC_COUNT_TTL_SECONDS = HOMEPAGE_CACHE_TTL_SECONDS
+
+# key -> (fetched_at_monotonic, value). Module-level, so each uWSGI worker keeps
+# its own copy: a few queries per TTL instead of one per request. Deliberately
+# not Redis -- a shared cache is another moving part that can itself be down, for
+# values this cheap to recompute. Assigning a whole tuple is atomic under the
+# GIL, so a concurrent refresh costs a duplicate query, never a torn read.
+_cache: dict = {}
+
+
+def _is_anonymous():
+    """True only if we're certain no user is logged in.
+
+    This gates every cache read and write, because `package_search` filters on
+    permission labels derived from the requesting user (see CKAN's
+    logic/action/get.py, "enforce permission filter based on user"): a sysadmin
+    gets `labels = None` and sees private datasets. Caching one user's results
+    under a shared key would serve their private dataset titles to the next
+    visitor.
+
+    Fails CLOSED. Anything unexpected -- no request context (CLI, tests,
+    background jobs), a CKAN version that moves `current_user` -- returns False,
+    which bypasses the cache and costs a query. The opposite default would leak.
+    """
+    try:
+        user = toolkit.current_user
+    except Exception:
+        return False
+    if user is None:
+        return False
+    try:
+        return bool(user.is_anonymous)
+    except Exception:
+        return False
+
+
+def _cached(key, refresh, default):
+    """Return `refresh()`'s value, memoised per worker for the TTL.
+
+    Logged-in (or unknown) users always get a live call, so their view is never
+    cached and never served from someone else's.
+
+    A failed refresh serves the previous value and still resets the timer, so a
+    struggling Solr is retried once per TTL rather than once per request. Solr
+    being slow should degrade the homepage's tiles, not 500 the page.
+    """
+    if not _is_anonymous():
+        return refresh()
+
+    entry = _cache.get(key)
+    now = time.monotonic()
+    if entry is not None and now - entry[0] < HOMEPAGE_CACHE_TTL_SECONDS:
+        return entry[1]
+
+    value = entry[1] if entry is not None else default
+    try:
+        value = refresh()
+    except Exception:
+        log.warning("Homepage cache refresh failed for %s; serving stale", key,
+                    exc_info=True)
+
+    _cache[key] = (now, value)
+    return value
 
 
 def _datasets(**params):
@@ -34,15 +91,27 @@ def _datasets(**params):
 
 
 def all_datasets():
-    return _datasets(sort="metadata_modified desc")
+    return _cached(
+        "all_datasets",
+        lambda: _datasets(sort="metadata_modified desc"),
+        [],
+    )
 
 
 def featured_datasets():
-    return _datasets(fq="tags:featured", sort="metadata_modified desc")
+    return _cached(
+        "featured_datasets",
+        lambda: _datasets(fq="tags:featured", sort="metadata_modified desc"),
+        [],
+    )
 
 
 def popular_datasets():
-    return _datasets(sort="views_recent desc")
+    return _cached(
+        "popular_datasets",
+        lambda: _datasets(sort="views_recent desc"),
+        [],
+    )
 
 
 def _refresh_topic_counts():
@@ -66,36 +135,16 @@ def _refresh_topic_counts():
 
 
 def topic_counts():
-    """Group-name -> dataset count, cached for TOPIC_COUNT_TTL_SECONDS.
+    """Group name -> dataset count, cached like the other homepage searches.
 
-    See ckanext-spark#7: an uncached version of this query ran on every homepage
-    load and coincided with the int container going unhealthy. Root cause was
-    never confirmed, and local measurement at 304 datasets puts this query at
-    27.8ms median -- indistinguishable from the three `package_search` calls the
-    homepage already made (25-27ms each). So this cache is not a proven fix for
-    that incident; it removes the query from the hot path so it cannot be the
-    cause of the next one, and that is all it claims.
-
-    A failed refresh serves the previous counts rather than raising. Solr being
-    slow or down should degrade the homepage's topic tiles to stale-or-zero, not
-    500 the whole page -- which is the failure mode #7 actually cared about.
+    See ckanext-spark#7: an uncached version of this ran on every homepage load
+    and coincided with the int container going unhealthy. Measured at 304
+    datasets it is 27.8ms -- indistinguishable from the three `package_search`
+    calls the homepage already made -- so this cache is not a proven fix for that
+    incident. It removes the query from the hot path so it cannot cause the next
+    one, and that is all it claims.
     """
-    global _topic_counts_cache
-    fetched_at, counts = _topic_counts_cache
-    now = time.monotonic()
-
-    if fetched_at is not None and now - fetched_at < TOPIC_COUNT_TTL_SECONDS:
-        return counts
-
-    try:
-        counts = _refresh_topic_counts()
-    except Exception:
-        # Keep serving the last good counts (or {} on the very first call) and
-        # back off for a full TTL so a struggling Solr isn't retried per request.
-        log.warning("Topic count refresh failed; serving stale counts", exc_info=True)
-
-    _topic_counts_cache = (now, counts)
-    return counts
+    return _cached("topic_counts", _refresh_topic_counts, {})
 
 
 def topics():

--- a/ckanext/spark/tests/test_helpers.py
+++ b/ckanext/spark/tests/test_helpers.py
@@ -7,6 +7,30 @@ import pytest
 import ckanext.spark.helpers as helpers
 import ckanext.spark.topics as topics
 
+# Captured before the autouse fixture stubs it out, so the tests below can
+# exercise the real gate rather than the stub.
+_REAL_IS_ANONYMOUS = helpers._is_anonymous
+
+
+@pytest.fixture(autouse=True)
+def _anonymous_with_empty_cache(monkeypatch):
+    """Every test starts anonymous with an empty cache.
+
+    Two separate hazards, both of which produce tests that pass for the wrong
+    reason: a populated cache means later tests assert against an earlier
+    test's values, and outside a request context `_is_anonymous()` fails closed,
+    so the cache would never engage and the caching tests would be vacuous.
+    """
+    helpers._cache.clear()
+    monkeypatch.setattr(helpers, "_is_anonymous", lambda: True)
+    yield
+    helpers._cache.clear()
+
+def _age_out(key):
+    """Push a cache entry past its TTL instead of sleeping through it."""
+    fetched_at, value = helpers._cache[key]
+    helpers._cache[key] = (fetched_at - helpers.HOMEPAGE_CACHE_TTL_SECONDS - 1, value)
+
 
 def test_format_date_formats_iso_timestamp():
     assert helpers.format_date("2026-07-23T13:14:15.000000") == "July 23, 2026"
@@ -27,6 +51,10 @@ def test_all_datasets_uses_single_search_action(monkeypatch):
 
     assert helpers.all_datasets() == [{"name": "example"}]
     assert calls == [({}, {"rows": 6, "sort": "metadata_modified desc"})]
+
+    # Second call inside the TTL is served from cache, not Solr.
+    assert helpers.all_datasets() == [{"name": "example"}]
+    assert len(calls) == 1
 
 
 def test_featured_datasets_filters_featured_tag(monkeypatch):
@@ -51,16 +79,6 @@ def test_featured_datasets_filters_featured_tag(monkeypatch):
     ]
 
 
-@pytest.fixture(autouse=True)
-def _clear_topic_cache():
-    """Empty the module-level topic-count cache around every test.
-
-    Without this, whichever topic test ran first would populate the cache and
-    every later one would silently assert against its counts instead of its own.
-    """
-    helpers._topic_counts_cache = (None, {})
-    yield
-    helpers._topic_counts_cache = (None, {})
 
 
 def _stub_topic_search(monkeypatch, facet_items, calls=None):
@@ -155,12 +173,7 @@ def test_topic_counts_refresh_after_the_ttl_expires(monkeypatch):
     _stub_topic_search(monkeypatch, [{"name": "education-learning", "count": 4}], calls)
 
     helpers.topics()
-    # Jump past the TTL rather than sleeping through it.
-    fetched_at, counts = helpers._topic_counts_cache
-    helpers._topic_counts_cache = (
-        fetched_at - helpers.TOPIC_COUNT_TTL_SECONDS - 1,
-        counts,
-    )
+    _age_out("topic_counts")
     helpers.topics()
 
     assert len(calls) == 2
@@ -178,11 +191,7 @@ def test_topic_counts_serve_stale_values_when_the_refresh_fails(monkeypatch):
         return _boom
 
     monkeypatch.setattr(helpers.toolkit, "get_action", explode)
-    fetched_at, counts = helpers._topic_counts_cache
-    helpers._topic_counts_cache = (
-        fetched_at - helpers.TOPIC_COUNT_TTL_SECONDS - 1,
-        counts,
-    )
+    _age_out("topic_counts")
 
     result = {t["name"]: t["count"] for t in helpers.topics()}
 
@@ -232,3 +241,84 @@ def test_topic_names_are_unique_and_url_safe():
     for name in names:
         # CKAN group names: lowercase alphanumerics, - and _, at least 2 chars.
         assert re.fullmatch(r"[a-z0-9_-]{2,100}", name), name
+
+
+def test_every_homepage_search_is_cached(monkeypatch):
+    """All four homepage searches, not just the topic counts (see #7 discussion).
+
+    A warm homepage should make zero Solr calls. Previously it made four.
+    """
+    calls = []
+
+    def package_search(context, data_dict):
+        calls.append(data_dict)
+        return {
+            "results": [],
+            "search_facets": {"groups": {"items": []}},
+        }
+
+    monkeypatch.setattr(helpers.toolkit, "get_action", lambda action: package_search)
+
+    def render_homepage():
+        helpers.all_datasets()
+        helpers.popular_datasets()
+        helpers.featured_datasets()
+        helpers.topics()
+
+    render_homepage()
+    assert len(calls) == 4, "cold cache should do exactly one query per helper"
+
+    calls.clear()
+    for _ in range(10):
+        render_homepage()
+    assert calls == [], "a warm homepage must not touch Solr at all"
+
+
+def test_logged_in_users_never_read_or_write_the_cache(monkeypatch):
+    """The privacy gate.
+
+    `package_search` filters on permission labels derived from the user, and a
+    sysadmin gets no filter at all -- so caching their results under a shared key
+    would serve private dataset titles to the next anonymous visitor. Logged-in
+    users must always go live, and must never populate the shared cache.
+    """
+    monkeypatch.setattr(helpers, "_is_anonymous", lambda: False)
+    calls = []
+
+    def package_search(context, data_dict):
+        calls.append(data_dict)
+        return {"results": [{"name": "a-private-dataset"}]}
+
+    monkeypatch.setattr(helpers.toolkit, "get_action", lambda action: package_search)
+
+    for _ in range(5):
+        helpers.all_datasets()
+
+    assert len(calls) == 5, "a logged-in user must always get a live query"
+    assert helpers._cache == {}, "a logged-in user must not populate the cache"
+
+
+def test_is_anonymous_fails_closed_without_a_request_context(monkeypatch):
+    """Outside a request there is no user to check, so caching must not engage.
+
+    Fail-closed is the whole point: the wrong default here leaks one user's
+    results to another.
+    """
+
+    monkeypatch.delattr(helpers.toolkit, "current_user", raising=False)
+
+    assert _REAL_IS_ANONYMOUS() is False
+
+
+def test_is_anonymous_is_false_for_a_logged_in_user(monkeypatch):
+    monkeypatch.setattr(
+        helpers.toolkit, "current_user", type("U", (), {"is_anonymous": False})()
+    )
+    assert _REAL_IS_ANONYMOUS() is False
+
+
+def test_is_anonymous_is_true_for_an_anonymous_visitor(monkeypatch):
+    monkeypatch.setattr(
+        helpers.toolkit, "current_user", type("U", (), {"is_anonymous": True})()
+    )
+    assert _REAL_IS_ANONYMOUS() is True

--- a/ckanext/spark/tests/test_helpers.py
+++ b/ckanext/spark/tests/test_helpers.py
@@ -2,6 +2,8 @@
 
 import re
 
+import pytest
+
 import ckanext.spark.helpers as helpers
 import ckanext.spark.topics as topics
 
@@ -49,7 +51,36 @@ def test_featured_datasets_filters_featured_tag(monkeypatch):
     ]
 
 
-def test_topics_returns_the_whole_taxonomy_in_order():
+@pytest.fixture(autouse=True)
+def _clear_topic_cache():
+    """Empty the module-level topic-count cache around every test.
+
+    Without this, whichever topic test ran first would populate the cache and
+    every later one would silently assert against its counts instead of its own.
+    """
+    helpers._topic_counts_cache = (None, {})
+    yield
+    helpers._topic_counts_cache = (None, {})
+
+
+def _stub_topic_search(monkeypatch, facet_items, calls=None):
+    """Point package_search at a canned `groups` facet response."""
+
+    def package_search(context, data_dict):
+        if calls is not None:
+            calls.append((context, data_dict))
+        return {
+            "count": 0,
+            "results": [],
+            "search_facets": {"groups": {"items": facet_items}},
+        }
+
+    monkeypatch.setattr(helpers.toolkit, "get_action", lambda action: package_search)
+
+
+def test_topics_returns_the_whole_taxonomy_in_order(monkeypatch):
+    _stub_topic_search(monkeypatch, [])
+
     result = helpers.topics()
 
     assert [topic["name"] for topic in result] == [
@@ -57,28 +88,141 @@ def test_topics_returns_the_whole_taxonomy_in_order():
     ]
     # A topic with no datasets still appears -- the taxonomy is the point, not
     # just the datasets currently in it.
-    assert all(topic["title"] for topic in result)
+    assert all(topic["count"] == 0 for topic in result)
 
 
-def test_topics_live_count_is_temporarily_disabled(monkeypatch):
-    """See ckanext-spark#7.
+def test_topics_merges_facet_counts_by_group_name(monkeypatch):
+    _stub_topic_search(
+        monkeypatch,
+        [
+            {"name": "education-learning", "count": 4},
+            {"name": "law-civil-rights", "count": 1},
+            # A group that isn't part of the taxonomy must not leak in.
+            {"name": "some-other-group", "count": 9},
+        ],
+    )
 
-    The `package_search` facet query this used to run on every homepage load
-    coincided with int becoming unhealthy shortly after this shipped. Root
-    cause wasn't confirmed, but this was the one thing added to every
-    homepage request, so it's disabled pending investigation. This test pins
-    that: topics() must not touch package_search at all right now, and every
-    count must read 0. Update/remove this once #7 restores a fix.
+    counts = {topic["name"]: topic["count"] for topic in helpers.topics()}
+
+    assert counts["education-learning"] == 4
+    assert counts["law-civil-rights"] == 1
+    assert counts["housing-urban-development"] == 0
+    assert "some-other-group" not in counts
+
+
+def test_topics_pins_the_facet_limit(monkeypatch):
+    """The count query must not inherit a facet cap from site config.
+
+    CKAN takes facet.limit from `search.facets.limit` (default 50), so all 11
+    topics come back today. Pinning -1 keeps that true if the config is lowered
+    or the taxonomy outgrows it, instead of quietly dropping the rarest topics.
     """
+    calls = []
+    _stub_topic_search(monkeypatch, [], calls)
 
-    def fail(*_args, **_kwargs):
-        raise AssertionError("topics() must not call get_action while disabled")
+    helpers.topics()
 
-    monkeypatch.setattr(helpers.toolkit, "get_action", fail)
+    (_context, data_dict), = calls
+    assert data_dict["facet.limit"] == -1
+    assert data_dict["rows"] == 0
+
+
+def test_topics_survives_an_empty_search_index(monkeypatch):
+    """A fresh site returns no search_facets key at all."""
+
+    monkeypatch.setattr(
+        helpers.toolkit,
+        "get_action",
+        lambda action: lambda context, data_dict: {"count": 0, "results": []},
+    )
+
+    assert len(helpers.topics()) == len(topics.SPARK_TOPICS)
+
+
+def test_topic_counts_are_cached_within_the_ttl(monkeypatch):
+    """The whole point of ckanext-spark#7: not one Solr query per homepage load."""
+    calls = []
+    _stub_topic_search(monkeypatch, [{"name": "education-learning", "count": 4}], calls)
+
+    for _ in range(25):
+        helpers.topics()
+
+    assert len(calls) == 1
+
+
+def test_topic_counts_refresh_after_the_ttl_expires(monkeypatch):
+    calls = []
+    _stub_topic_search(monkeypatch, [{"name": "education-learning", "count": 4}], calls)
+
+    helpers.topics()
+    # Jump past the TTL rather than sleeping through it.
+    fetched_at, counts = helpers._topic_counts_cache
+    helpers._topic_counts_cache = (
+        fetched_at - helpers.TOPIC_COUNT_TTL_SECONDS - 1,
+        counts,
+    )
+    helpers.topics()
+
+    assert len(calls) == 2
+
+
+def test_topic_counts_serve_stale_values_when_the_refresh_fails(monkeypatch):
+    """A struggling Solr must degrade the tiles, not 500 the homepage."""
+    _stub_topic_search(monkeypatch, [{"name": "education-learning", "count": 4}])
+    helpers.topics()
+
+    def explode(action):
+        def _boom(context, data_dict):
+            raise RuntimeError("solr is having a moment")
+
+        return _boom
+
+    monkeypatch.setattr(helpers.toolkit, "get_action", explode)
+    fetched_at, counts = helpers._topic_counts_cache
+    helpers._topic_counts_cache = (
+        fetched_at - helpers.TOPIC_COUNT_TTL_SECONDS - 1,
+        counts,
+    )
+
+    result = {t["name"]: t["count"] for t in helpers.topics()}
+
+    assert result["education-learning"] == 4, "should still serve the last good count"
+
+
+def test_topic_counts_return_zeros_when_the_first_ever_refresh_fails(monkeypatch):
+    """Cold cache plus a broken Solr still has to render a page."""
+
+    def explode(action):
+        def _boom(context, data_dict):
+            raise RuntimeError("solr is down")
+
+        return _boom
+
+    monkeypatch.setattr(helpers.toolkit, "get_action", explode)
 
     result = helpers.topics()
 
+    assert len(result) == len(topics.SPARK_TOPICS)
     assert all(topic["count"] == 0 for topic in result)
+
+
+def test_failed_refresh_backs_off_instead_of_retrying_every_request(monkeypatch):
+    """Retrying a broken Solr once per request is how a blip becomes an outage."""
+    calls = []
+
+    def explode(action):
+        def _boom(context, data_dict):
+            calls.append(1)
+            raise RuntimeError("solr is down")
+
+        return _boom
+
+    monkeypatch.setattr(helpers.toolkit, "get_action", explode)
+
+    for _ in range(25):
+        helpers.topics()
+
+    assert len(calls) == 1
 
 
 def test_topic_names_are_unique_and_url_safe():


### PR DESCRIPTION
Restores the live topic count that #8 disabled, and — per @langdon's "the solr
call on the front page should be doing some caching if possible anyway" — takes
**all four** of the homepage's uncached searches off the per-request path.

## The homepage was making four uncached searches, not one

`all_datasets`, `popular_datasets`, `featured_datasets` and the topic counts
each ran a `package_search` on every load. #9 originally only fixed the last one.

A/B'd on the running dev stack by toggling the TTL (median of 8 loads):

| | median |
|---|---|
| cache **on** (TTL=60) | **0.212s** |
| cache **off** (TTL=0) | 0.582s |

**~370ms of a 582ms page — about 64% of the homepage's time.** A warm page now
makes **zero** Solr calls instead of four.

That's a much bigger number than the "roughly 28ms" I quoted earlier, and worth
explaining rather than glossing: that figure was for the topic count *alone*, and
it came from an isolated benchmark reusing a warm connection. In-request each
call also deserializes package dicts and computes permission labels, so the real
cost is higher than the isolated timing suggested.

## Caching these is NOT the same problem as caching the counts

This is the part worth reviewing closely. `package_search` filters on permission
labels derived from the requesting user — `ckan/logic/action/get.py`, *"enforce
permission filter based on user"* — and a **sysadmin gets `labels = None`**,
meaning they see private datasets.

So caching dataset lists under a single shared key is a **privacy leak**, not
merely a staleness question: a sysadmin loads the homepage, their "recently
modified" includes a private dataset, that response is cached, and the next
anonymous visitor sees private dataset titles.

Mitigation:

- The cache is gated on `_is_anonymous()`. Logged-in users **always** go live and
  **never** populate the shared cache.
- That gate **fails closed**. No request context (CLI, tests, background jobs),
  or a future CKAN that moves `current_user`, returns `False` and costs a live
  query. The opposite default would leak.
- The topic-count cache had the same flaw in milder form — counts could be
  inflated for anonymous visitors if an admin warmed them — so it now goes
  through the same gate.

## On the original incident

Unchanged from my earlier comment on #7 and worth repeating here so this isn't
merged as a fix for something it may not fix: with 304 datasets locally the
topic query measured **27.8ms**, indistinguishable from the three searches the
homepage already made, and I could not reproduce the failure. @langdon's current
read — the host may not have capacity for Herbaria and Data@Spark together —
fits the evidence better than a 28ms query, and a hanging `podman exec` looks
like resource exhaustion.

This PR makes the homepage substantially cheaper, which helps if the host is
contended. It is **not** proof of root cause. I'd keep #7 open on that question.

It does fix a real robustness bug independent of all that: the previous code
propagated any Solr exception straight into the page and retried a struggling
Solr once per request. Now a failed refresh serves the last good values and backs
off for a full TTL.

## Verification

- **21 tests pass.** Restores the three #8 removed; adds all-four-cached (cold
  cache = exactly 4 queries, 10 warm renders = 0), logged-in users neither read
  nor write the cache, and `_is_anonymous` fails closed without a request
  context.
- The autouse fixture clears the shared cache *and* forces the gate open —
  without the latter the caching tests would be vacuous, since outside a request
  context the gate correctly refuses to cache.
- On the running stack: anonymous homepage renders correct counts, logged-in
  sysadmin still gets a working page.

## Deploying

Needs `CKANEXT_SPARK_COMMIT` bumped in `ckan-docker` (`data-at-spark/Dockerfile`
plus the default in `data-at-spark/compose.yml`) before it reaches int.

Refs #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012badxi5vu4W6ku99EucbRE